### PR TITLE
Allow users to specify explicit path to nfdump executable

### DIFF
--- a/pynfdump/nfdump.py
+++ b/pynfdump/nfdump.py
@@ -118,7 +118,7 @@ class Dumper:
         self.profile = profile
         self.sources = maybe_split(sources, ',')
         self.remote_host = remote_host
-	self.exec_path = executable_path
+        self.exec_path = executable_path
         if os.path.isdir(self.exec_path):
             self.exec_path = os.path.join(self.exec_path, "nfdump")
         self.set_where()


### PR DESCRIPTION
In my installation, I installed nfdump under /opt and it is not in the global path.  This merge allows one to specify executable_path when one instantiates Dumper() so that the executable can be properly called.
